### PR TITLE
Move counter & pawn driver fix

### DIFF
--- a/drivers/pawn-movement.cpp
+++ b/drivers/pawn-movement.cpp
@@ -12,8 +12,8 @@ int main() {
 
 
     // Add the pawns to the game board
-    board.addPiece(6,2,&whiteCpawn);
-    board.addPiece(1,5,&blackFPawn);
+    board.addPiece(1,5,&whiteCpawn);
+    board.addPiece(6,2,&blackFPawn);
     
     // Check to ensure our pawns were added properly
     board.visualiseTextBoard();
@@ -24,14 +24,21 @@ int main() {
     board.movePiece(6,2, 6,3);
     board.movePiece(1,5, 1,4);
 
-    // Check to ensure our nothing has happened
+    // Check to ensure nothing has happened
     board.visualiseTextBoard();
 
     // Move the pawns to legal positions 
-    board.movePiece(6,2, 5,2);
+    board.movePiece(6,2, 4,2);
     board.movePiece(1,5, 2,5);
 
     // Check to ensure our moves were successful
+    board.visualiseTextBoard();
+
+    // Move the pawns to illegal positions
+    board.movePiece(4,2, 2,2);
+    board.movePiece(2,5, 4,5);
+
+    // Check to ensure nothing has happened
     board.visualiseTextBoard();
 
     return 0;

--- a/include/gameboard.cpp
+++ b/include/gameboard.cpp
@@ -42,6 +42,7 @@ bool gameboard::movePiece(int oldRank, int oldFile, int newRank, int newFile) {
         }
         addPiece(newRank,newFile,piece); // Add the piece in the target location
         removePiece(oldRank,oldFile); // Remove the piece from the original location
+        piece->move(); // increment piece's move count
 
         // report successful move
         return true;

--- a/include/pawn.cpp
+++ b/include/pawn.cpp
@@ -25,9 +25,11 @@ bool pawn::checkMoveValidity(int oldRank, int oldFile, int newRank, int newFile)
     bool valid;
     // check pawns are moving up one space
     if (this->_color == 'B') {
-        valid = (oldFile == newFile) && (oldRank-newRank == 1);
+        valid = (oldFile == newFile) && (oldRank-newRank == 1 
+        || (this->_moveCount == 1 && oldRank-newRank == 2)); // can move 2 places first move
     } else { // Uncolored pawns are white by default
-        valid = (oldFile == newFile) && (newRank-oldRank == 1);
+        valid = (oldFile == newFile) && (newRank-oldRank == 1 
+        || (this->_moveCount == 1 && newRank-oldRank == 2)); // can move 2 places first move
     }
     return valid;
 }

--- a/include/piece.cpp
+++ b/include/piece.cpp
@@ -1,8 +1,10 @@
 #include "piece.h"
 
 piece::piece(): piece('x','W') {}
-piece::piece(char name, char color) : _captured(false), _name(name), _color(color) {}
+piece::piece(char name, char color) : _captured(false), _name(name), 
+                                    _color(color), _moveCount(1) {}
 
 void piece::capture() {this->_captured = true;}
 bool piece::captured() {return this->_captured;}
 char piece::getName() {return this->_name;}
+void piece::move() {_moveCount++;}

--- a/include/piece.h
+++ b/include/piece.h
@@ -6,6 +6,7 @@ class piece {
         bool _captured;
         char _name;
         char _color;
+        int _moveCount;
     public:
         piece();
         piece(char name, char color);
@@ -13,6 +14,7 @@ class piece {
         bool captured();
         virtual bool checkMoveValidity(int oldRank, int oldFile, int newRank, int newFile) = 0;
         char getName();
+        void move();
 };
 
 #endif//PIECE_H


### PR DESCRIPTION
All pieces now track the number of moves they've successfully taken. This number is incremented with the move() method. Pawns can now move up 2 spaces on their first turn. The pawn driver has also been fixed, as the white piece was being placed on the black side and vice versa.