### PR TITLE
Draw agreement

### DIFF
--- a/include/Game.hpp
+++ b/include/Game.hpp
@@ -41,12 +41,6 @@ class Game{
         return successfulMove;
     }
 
-    void saveState() {
-        /* 
-        To be added.
-        */
-    }
-
     void loadState() {
         /* 
         To be added.

--- a/include/UI.hpp
+++ b/include/UI.hpp
@@ -79,8 +79,8 @@ class UI {
 
         uiBoard = new UIBoard(BOARD_LENGTH,BOARD_HEIGHT,Vector2i(PADDING,GUTTER_HEIGHT));
 
-        whiteText = new UIText(Vector2f(PADDING,TOP_TEXT_Y),"White");
-        blackText = new UIText(Vector2f(PADDING,BOTTOM_TEXT_Y),"Black");
+        whiteText = new UIText(Vector2f(PADDING,BOTTOM_TEXT_Y),"White");
+        blackText = new UIText(Vector2f(PADDING,TOP_TEXT_Y),"Black");
         matchText = new UIText(Vector2f(CONTROL_X,TOP_TEXT_Y),"White vs. Black");
 
         moveStack = new UIMoveStack(Vector2f(CONTROL_X,GUTTER_HEIGHT),10);

--- a/include/UI.hpp
+++ b/include/UI.hpp
@@ -40,6 +40,8 @@ class UI {
 
         bool isAlertDisplayed = false;
 
+        bool drawOffered = false;
+
     public:
     UI() {
         game = new Game();
@@ -138,6 +140,9 @@ class UI {
 
                                 // If the game has ended, display an alert to show this
                                 if (game->getGameState() != '0') { displayAlert(game->getGameState(), game->getOppositeColorToMove()); }
+
+                                // Reset the draw button, if it was not accepted
+                                resetDrawButton();
                             }
                         }
                     }
@@ -163,9 +168,8 @@ class UI {
 
     // Is a button currently hovered? If so, we run its command
     void runButtonCommands(int x, int y) {
-        if (saveButton->isHovered(x,y))   { game->saveState(); }                                // Save command
         if (loadButton->isHovered(x,y))   { game->loadState(); }                                // Load command
-        if (drawButton->isHovered(x,y))   { displayAlert('A',game->getOppositeColorToMove()); } // Draw command
+        if (drawButton->isHovered(x,y))   { drawButtonClick(); } // Draw command
         if (resignButton->isHovered(x,y)) { displayAlert('R',game->getColorToMove()); }         // Resign command
         
         // If our alert is displayed, we can interact with its buttons
@@ -173,6 +177,23 @@ class UI {
             if (alert->primaryButton->isHovered(x,y)) { resetControls(); } // Primary button command (play again) 
             if (alert->secondaryButton->isHovered(x,y)) { window->close(); } // Secondary button command (quit)
         }
+    }
+
+    void resetDrawButton () {
+        drawButton->setButtonText("Offer Draw");
+        drawOffered = false;
+    }
+
+    void drawButtonClick() {
+        if (!drawOffered) {
+            drawButton->setButtonText("Accept Draw");
+            drawOffered = true;
+        } else {
+            displayAlert('A',game->getOppositeColorToMove()); 
+            resetDrawButton();
+            drawOffered = false;
+        }
+
     }
 
     // Is a button currently hovered? If so, invert its colors

--- a/include/UI.hpp
+++ b/include/UI.hpp
@@ -41,6 +41,7 @@ class UI {
         bool isAlertDisplayed = false;
 
         bool drawOffered = false;
+        bool resignOffered = false;
 
     public:
     UI() {
@@ -142,7 +143,7 @@ class UI {
                                 if (game->getGameState() != '0') { displayAlert(game->getGameState(), game->getOppositeColorToMove()); }
 
                                 // Reset the draw button, if it was not accepted
-                                resetDrawButton();
+                                resetButtonStates();
                             }
                         }
                     }
@@ -157,7 +158,7 @@ class UI {
                     int x = event.mouseMove.x;
                     int y = event.mouseMove.y;
 
-                    updateButtonStates(x,y);
+                    updateButtonColors(x,y);
                 }
 
             }
@@ -171,16 +172,18 @@ class UI {
         if (!isAlertDisplayed) {
             if (loadButton->isHovered(x,y))   { game->loadState(); }                        // Load command
             if (drawButton->isHovered(x,y))   { drawButtonClick(); }                        // Draw command
-            if (resignButton->isHovered(x,y)) { displayAlert('R',game->getColorToMove()); } // Resign command
+            if (resignButton->isHovered(x,y)) { resignButtonClick(); } // Resign command
         } else {
             if (alert->primaryButton->isHovered(x,y)) { resetControls(); } // Primary button command (play again) 
             if (alert->secondaryButton->isHovered(x,y)) { window->close(); } // Secondary button command (quit)
         }
     }
 
-    void resetDrawButton () {
+    void resetButtonStates() {
         drawButton->setButtonText("Offer Draw");
+        resignButton->setButtonText("Resign");
         drawOffered = false;
+        resignOffered = false;
     }
 
     void drawButtonClick() {
@@ -189,14 +192,22 @@ class UI {
             drawOffered = true;
         } else {
             displayAlert('A',game->getOppositeColorToMove()); 
-            resetDrawButton();
-            drawOffered = false;
+            resetButtonStates();
         }
+    }
 
+    void resignButtonClick() {
+        if (!resignOffered) {
+            resignButton->setButtonText("Accept Resignation");
+            resignOffered = true;
+        } else {
+            displayAlert('R',game->getColorToMove()); 
+            resetButtonStates();
+        }
     }
 
     // Is a button currently hovered? If so, invert its colors
-    void updateButtonStates(int x, int y) {
+    void updateButtonColors(int x, int y) {
         saveButton->updateButtonColors(x,y);
         loadButton->updateButtonColors(x,y);
         drawButton->updateButtonColors(x,y);

--- a/include/UI.hpp
+++ b/include/UI.hpp
@@ -154,8 +154,8 @@ class UI {
 
                 // Handle the appropriate behavior for moving the mouse
                 if (event.type == sf::Event::MouseMoved) {
-                    int x = event.mouseButton.x;
-                    int y = event.mouseButton.y;
+                    int x = event.mouseMove.x;
+                    int y = event.mouseMove.y;
 
                     updateButtonStates(x,y);
                 }
@@ -168,12 +168,11 @@ class UI {
 
     // Is a button currently hovered? If so, we run its command
     void runButtonCommands(int x, int y) {
-        if (loadButton->isHovered(x,y))   { game->loadState(); }                                // Load command
-        if (drawButton->isHovered(x,y))   { drawButtonClick(); } // Draw command
-        if (resignButton->isHovered(x,y)) { displayAlert('R',game->getColorToMove()); }         // Resign command
-        
-        // If our alert is displayed, we can interact with its buttons
-        if (isAlertDisplayed) {
+        if (!isAlertDisplayed) {
+            if (loadButton->isHovered(x,y))   { game->loadState(); }                        // Load command
+            if (drawButton->isHovered(x,y))   { drawButtonClick(); }                        // Draw command
+            if (resignButton->isHovered(x,y)) { displayAlert('R',game->getColorToMove()); } // Resign command
+        } else {
             if (alert->primaryButton->isHovered(x,y)) { resetControls(); } // Primary button command (play again) 
             if (alert->secondaryButton->isHovered(x,y)) { window->close(); } // Secondary button command (quit)
         }

--- a/include/UI.hpp
+++ b/include/UI.hpp
@@ -201,7 +201,7 @@ class UI {
             resignButton->setButtonText("Accept Resignation");
             resignOffered = true;
         } else {
-            displayAlert('R',game->getColorToMove()); 
+            displayAlert('R',game->getOppositeColorToMove()); 
             resetButtonStates();
         }
     }

--- a/include/UIButton.hpp
+++ b/include/UIButton.hpp
@@ -33,13 +33,16 @@ class UIButton : public Drawable, public Transformable
         buttonComponent->setPosition(position);
         buttonComponent->setFillColor(buttonColor);
 
-        // Create text component
-        textComponent = new UIText(position, text, fontSize, fontColor);
+        // Create text component (filled with "Level" to make sure any text is rendered at the same height)
+        textComponent = new UIText(position, "Level", fontSize, fontColor);
 
         // Center text in button
         const sf::FloatRect bounds(textComponent->element.getLocalBounds());
         const sf::Vector2f box(buttonComponent->getSize());
         textComponent->element.setOrigin((bounds.width - box.x) / 2 + bounds.left, (bounds.height - box.y) / 2 + bounds.top);
+
+        // Set the button text without modifying the height
+        setButtonText(text);
     }
 
     // Returns whether the button is hovered over

--- a/include/UIButton.hpp
+++ b/include/UIButton.hpp
@@ -51,7 +51,7 @@ class UIButton : public Drawable, public Transformable
     // Updates a button's colors depending on whether it is hovered over
     void updateButtonColors(int x, int y) { 
         bool invert = isHovered(x,y);
-        
+
         // If the button is not hovered, color it in the standard fashion
         if (!invert) {
             buttonComponent->setFillColor(_standardColor);
@@ -60,7 +60,7 @@ class UIButton : public Drawable, public Transformable
         // Otherwise, invert its colors
         } else {
             buttonComponent->setFillColor(_inverseColor);   
-            textComponent->element.setFillColor(_standardColor);            
+            textComponent->element.setFillColor(_standardColor);         
         }
     }
     

--- a/include/UIButton.hpp
+++ b/include/UIButton.hpp
@@ -63,6 +63,16 @@ class UIButton : public Drawable, public Transformable
             textComponent->element.setFillColor(_standardColor);            
         }
     }
+    
+    // Sets the button's text content
+    void setButtonText(string text) {
+        textComponent->element.setString(text);
+
+        // Center text in button
+        const sf::FloatRect bounds(textComponent->element.getLocalBounds());
+        const sf::Vector2f box(buttonComponent->getSize());
+        textComponent->element.setOrigin((int)((bounds.width - box.x) / 2 + bounds.left), textComponent->element.getOrigin().y);
+    }
 
     // Draws the button
     virtual void draw(RenderTarget& target, RenderStates states) const


### PR DESCRIPTION
Drawing and resignation is now a two-step process, allowing players to agree. If a draw/resignation is not accepted, the button reverts to its original state on the next turn.

All button text is now set to the same baseline (so it looks less janky!)